### PR TITLE
Update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,4 @@ Copyright &copy; 2016. The [Compute.io][compute-io] Authors.
 [factorial-function]: https://github.com/math-io/factorial
 [real]: https://en.wikipedia.org/wiki/Real_number
 [complex]: https://en.wikipedia.org/wiki/Complex_number
-[euler-mascheroni-constant]: https://github.com/compute-io/const-eulergamma
+[euler-mascheroni-constant]: https://github.com/const-io/eulergamma

--- a/lib/small_approximation.js
+++ b/lib/small_approximation.js
@@ -2,7 +2,7 @@
 
 // CONSTANTS //
 
-var EULER = require( 'compute-const-eulergamma' );
+var EULER = require( 'const-eulergamma' );
 
 
 // GAMMA //

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "https://github.com/math-io/gamma/issues"
   },
   "dependencies": {
-    "compute-const-eulergamma": "^1.0.1",
+    "const-eulergamma": "^1.0.3",
     "const-ninf-float64": "^1.0.0",
     "const-pi": "^1.0.3",
     "const-pinf-float64": "^1.0.0",


### PR DESCRIPTION
This PR
- swaps `compute-const-eulergamma` for `const-eulergamma`
- update docs to point to `const-io/eulergamma`
